### PR TITLE
Add support for leader-elected hook event

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -3,10 +3,11 @@
 Since the charms.reactive framework does not use the Operator framework's event
 system, most events at the charm level will be missing or ignored. However, the
 library will ensure that the events for the specific relation endpoints to
-which the API instances are bound, as well as the `upgrade_charm` event, will
-be emitted, so that the classes can use them as they would in an Operator
-framework charm. Additionally, any internal events emitted and observed by the
-API classes, as well as deferred events, will function as expected.
+which the API instances are bound, as well as either the `upgrade_charm` or
+`leader-elected` events, will be emitted, so that the classes can use them as
+they would in an Operator framework charm. Additionally, any internal events
+emitted and observed by the API classes, as well as deferred events, will
+function as expected.
 
 Note that these events are processed before the flags for the interface API
 instance are managed, meaning those event handlers can be used to manage [stored

--- a/ops_reactive_interface.py
+++ b/ops_reactive_interface.py
@@ -107,8 +107,15 @@ class InterfaceAPIFactory:
         hook_name = hookenv.hook_name()
 
         # Check for and emit upgrade_charm event.
+        # (Might be needed for data format changes.)
         if hook_name == 'upgrade-charm':
             cls._charm.on.upgrade_charm.emit()
+            return
+
+        # Check for and emit leader_elected event.
+        # (Might be needed for app rel data.)
+        if hook_name == 'leader-elected':
+            cls._charm.on.leader_elected.emit()
             return
 
         # Check for relation events for bound classes.

--- a/tests/unit/test_ops_reactive_interface.py
+++ b/tests/unit/test_ops_reactive_interface.py
@@ -64,6 +64,7 @@ def test_startup(harness):
     fw.observe(charm.on.config_changed, observer.call)
     fw.observe(charm.on.give_relation_created, observer.call)
     fw.observe(charm.on.upgrade_charm, observer.call)
+    fw.observe(charm.on.leader_elected, observer.call)
 
     hookenv.hook_name.return_value = 'config-changed'
     IAF._startup()
@@ -109,3 +110,8 @@ def test_startup(harness):
     observer.called = None
     IAF._startup()
     assert observer.called == 'UpgradeCharmEvent'
+
+    hookenv.hook_name.return_value = 'leader-elected'
+    observer.called = None
+    IAF._startup()
+    assert observer.called == 'LeaderElectedEvent'


### PR DESCRIPTION
For interfaces which use app-level relation data, the leader-elected hook is important to be able to handle. This adds that to the limited set of events which are emitted by the reactive charm shim.